### PR TITLE
fix: Address various clippy issues

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -372,7 +372,7 @@ pub fn launch_northstar_steam(
     }
 
     // Switch to Titanfall2 directory to set everything up
-    if std::env::set_current_dir(game_install.game_path.clone()).is_err() {
+    if std::env::set_current_dir(game_install.game_path).is_err() {
         // We failed to get to Titanfall2 directory
         return Err("Couldn't access Titanfall2 directory".to_string());
     }
@@ -415,7 +415,7 @@ pub fn launch_northstar_steam(
         }
     });
 
-    return retval;
+    retval
 }
 
 pub fn check_origin_running() -> bool {


### PR DESCRIPTION
Addresses [clippy](https://doc.rust-lang.org/stable/clippy/usage.html) warnings caused by newly introduced code from https://github.com/R2NorthstarTools/FlightCore/pull/178

It's just minor things. Not really an issue but as I'm currently in the process of getting warnings down to zero it's probably best not to introduce new ones ^^